### PR TITLE
Fix: Resolve Trigger Claude Code workflow authentication failures

### DIFF
--- a/.github/workflows/claude-backend.yaml
+++ b/.github/workflows/claude-backend.yaml
@@ -32,8 +32,10 @@ jobs:
 
       - name: Configure Git 
         run: |
-          git config --global user.name "<GIT USERNAME>"
-          git config --global user.email "<GIT USER EMAIL>"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global credential.helper store
+          echo "https://x-access-token:${{ secrets.PORT_GITHUB_TOKEN }}@github.com" > ~/.git-credentials
 
       - name: Execute Claude Code
         id: claude_execution


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem Summary

The "Trigger Claude Code" workflow has been **failing consistently since 2026-07-13** with 8+ consecutive failures on the main branch. All failures were due to **403 permission errors** when attempting to push changes to target repositories.

### Failed Run Details
- **Failed Run:** https://github.com/port-gh-app-dev/github-actions-backend/actions/runs/29279582240
- **Error:** `remote: Permission to port-gh-app-dev/payment-service.git denied to PeyGis`
- **Status:** 403 Forbidden when pushing changes

## Root Cause Analysis

The workflow had two critical issues in the git configuration step:

1. **Placeholder values instead of actual credentials:**
   ```yaml
   git config --global user.name "<GIT USERNAME>"
   git config --global user.email "<GIT USER EMAIL>"
   ```

2. **Missing git credential configuration:** The checkout action configured authentication, but it wasn't persisting for the Claude Code action's push operations.

## Solution

This PR fixes both issues by:

1. **Replacing placeholder values** with proper GitHub Actions bot credentials:
   ```yaml
   git config --global user.name "github-actions[bot]"
   git config --global user.email "github-actions[bot]@users.noreply.github.com"
   ```

2. **Configuring git credential storage** to enable authenticated push operations:
   ```yaml
   git config --global credential.helper store
   echo "https://x-access-token:${{ secrets.PORT_GITHUB_TOKEN }}@github.com" > ~/.git-credentials
   ```

## Changes Made

- ✅ Fixed git user configuration with valid bot credentials
- ✅ Added git credential helper configuration
- ✅ Configured PORT_GITHUB_TOKEN for push authentication

## Testing Plan

The fix ensures:
- Git identity is properly configured for commits
- Authentication token is available for push operations
- Claude Code action can successfully create branches and open PRs

## Impact

- **Resolves:** 8+ consecutive workflow failures since 2026-07-13
- **Affected Workflow:** `.github/workflows/claude-backend.yaml`
- **Risk Level:** Low - Only changes git configuration, no business logic affected

## Related Links

- Failed workflow run: https://github.com/port-gh-app-dev/github-actions-backend/actions/runs/29279582240
- Workflow file: `.github/workflows/claude-backend.yaml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9728d16-fd39-4a5a-90a5-ee802b227657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9728d16-fd39-4a5a-90a5-ee802b227657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

